### PR TITLE
Fix Incorrect Command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the vagrant user as described below:
 ### Rails
 ```bash
 cd ~/canvas-lms
-bundle exec rails --binding 0.0.0.0
+bundle exec rails server --binding 0.0.0.0
 ```
 
 ### Delayed job


### PR DESCRIPTION
`bundle exec rails --binding 0.0.0.0` fails with `invalid option: --binding`.
`bundle exec rails server --binding 0.0.0.0` appears to be the correct command.